### PR TITLE
Papilio 105 logout

### DIFF
--- a/app/src/main/java/com/soen490chrysalis/papilio/view/AccountMenuFragment.kt
+++ b/app/src/main/java/com/soen490chrysalis/papilio/view/AccountMenuFragment.kt
@@ -34,12 +34,17 @@ class AccountMenuFragment : Fragment()
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.account_menu_fragment, container, false)
         val profileButton = view.findViewById<androidx.appcompat.widget.AppCompatButton>(R.id.account_user_profile)
+        val logoutButton = view.findViewById<androidx.appcompat.widget.AppCompatButton>(R.id.account_logout)
 
         profileButton?.setOnClickListener {
             val intent = Intent(this.activity, UserProfileActivity::class.java)
             startActivity(intent)
         }
 
+        logoutButton?.setOnClickListener{
+            val intent = Intent(this.activity, LoginActivity::class.java)
+            startActivity(intent)
+        }
         return view
     }
 }

--- a/app/src/main/java/com/soen490chrysalis/papilio/view/AccountMenuFragment.kt
+++ b/app/src/main/java/com/soen490chrysalis/papilio/view/AccountMenuFragment.kt
@@ -6,6 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.firebase.auth.FirebaseAuth
 import com.soen490chrysalis.papilio.R
 import com.soen490chrysalis.papilio.databinding.AccountMenuFragmentBinding
 import kotlinx.android.synthetic.main.account_menu_fragment.*
@@ -42,8 +45,18 @@ class AccountMenuFragment : Fragment()
         }
 
         logoutButton?.setOnClickListener{
+            //Firebase sign out
+            FirebaseAuth.getInstance().signOut()
+
+            //Google sign out
+            val googleSignInClient = GoogleSignIn.getClient(requireContext(), GoogleSignInOptions.DEFAULT_SIGN_IN)
+            googleSignInClient.signOut()
+
             val intent = Intent(this.activity, LoginActivity::class.java)
             startActivity(intent)
+
+            //prevents user from using "back" to go to previous screen
+            activity?.finish()
         }
         return view
     }

--- a/app/src/main/java/com/soen490chrysalis/papilio/view/AccountMenuFragment.kt
+++ b/app/src/main/java/com/soen490chrysalis/papilio/view/AccountMenuFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseAuth
-import com.soen490chrysalis.papilio.R
 import com.soen490chrysalis.papilio.databinding.AccountMenuFragmentBinding
 import kotlinx.android.synthetic.main.account_menu_fragment.*
 import kotlinx.android.synthetic.main.account_menu_fragment.view.*
@@ -23,7 +22,6 @@ class AccountMenuFragment : Fragment()
 {
     private lateinit var binding : AccountMenuFragmentBinding
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = AccountMenuFragmentBinding.inflate(layoutInflater)
@@ -35,16 +33,13 @@ class AccountMenuFragment : Fragment()
     ) : View?
     {
         // Inflate the layout for this fragment
-        val view = inflater.inflate(R.layout.account_menu_fragment, container, false)
-        val profileButton = view.findViewById<androidx.appcompat.widget.AppCompatButton>(R.id.account_user_profile)
-        val logoutButton = view.findViewById<androidx.appcompat.widget.AppCompatButton>(R.id.account_logout)
+        binding = AccountMenuFragmentBinding.inflate(inflater, container, false)
 
-        profileButton?.setOnClickListener {
-            val intent = Intent(this.activity, UserProfileActivity::class.java)
+        binding.accountUserProfile.setOnClickListener {
+            val intent = Intent(requireActivity(), UserProfileActivity::class.java)
             startActivity(intent)
         }
-
-        logoutButton?.setOnClickListener{
+        binding.accountLogout.setOnClickListener{
             //Firebase sign out
             FirebaseAuth.getInstance().signOut()
 
@@ -52,12 +47,13 @@ class AccountMenuFragment : Fragment()
             val googleSignInClient = GoogleSignIn.getClient(requireContext(), GoogleSignInOptions.DEFAULT_SIGN_IN)
             googleSignInClient.signOut()
 
-            val intent = Intent(this.activity, LoginActivity::class.java)
+            val intent = Intent(requireActivity(), LoginActivity::class.java)
             startActivity(intent)
 
             //prevents user from using "back" to go to previous screen
-            activity?.finish()
+            requireActivity().finish()
         }
-        return view
+
+        return binding.root
     }
 }


### PR DESCRIPTION
# General info

**Issue number**: PAPILIO-105

**Task description**: 
 -Allow users to logout of the mobile application

# Testing
To test this feature you have to:

1. Sign in to Papilio with your preferred method of choice
2. Navigate to the "Account" tab
3. Click on "LOGOUT"
4. Ensure that previous page may not be returned to by using android's "back" system navigation
5. Kill the app, run it once more, and ensure that the profile is not automatically logged back in (i.e. user is prompted to login again)
